### PR TITLE
Fix for #411 and #412

### DIFF
--- a/app/views/jobs/resultpanels/hhblits/hitlist.scala.html
+++ b/app/views/jobs/resultpanels/hhblits/hitlist.scala.html
@@ -117,20 +117,22 @@
 <script>
 
         var hitsToLoad = 50;
+        @if(result.num_hits > 0){
 
-        $(function(){
-            var context = {
-                numHits: @result.num_hits,
-                toolName: "@tool.toolNameShort",
-                firstQueryStart: @result.HSPS.head.query.start,
-                firstQueryEnd: @result.HSPS.head.query.end,
-                query: {
-                    seq: "@result.query.seq",
-                    accession: "@result.query.accession"
-                }
-            };
-            Toolkit.resultView = new NormalResultView($("#jobview"), "@{jobID}", hitsToLoad, true, false, context);
-        });
+            $(function(){
+                var context = {
+                    numHits: @result.num_hits,
+                    toolName: "@tool.toolNameShort",
+                    firstQueryStart: @result.HSPS.head.query.start,
+                    firstQueryEnd: @result.HSPS.head.query.end,
+                    query: {
+                        seq: "@result.query.seq",
+                        accession: "@result.query.accession"
+                    }
+                };
+                Toolkit.resultView = new NormalResultView($("#jobview"), "@{jobID}", hitsToLoad, true, false, context);
+            });
+        }
 
 </script>
 

--- a/app/views/jobs/resultpanels/hhomp/hitlist.scala.html
+++ b/app/views/jobs/resultpanels/hhomp/hitlist.scala.html
@@ -97,18 +97,19 @@
 <script>
         var shownHits = 100;
 
-        $(function () {
-            var context = {
-                numHits: @result.num_hits,
-                toolName: "@tool.toolNameShort",
-                firstQueryStart: @result.HSPS.head.query.start,
-                firstQueryEnd: @result.HSPS.head.query.end,
-                query: {
-                    seq: "@result.query.seq",
-                    accession: "@result.query.accession"
-                }
-            };
-            Toolkit.resultView = new NormalResultView($("#jobview"), "@{jobID}", shownHits, true, true, context);
-        });
-
+        @if(result.num_hits > 0){
+            $(function () {
+                var context = {
+                    numHits: @result.num_hits,
+                    toolName: "@tool.toolNameShort",
+                    firstQueryStart: @result.HSPS.head.query.start,
+                    firstQueryEnd: @result.HSPS.head.query.end,
+                    query: {
+                        seq: "@result.query.seq",
+                        accession: "@result.query.accession"
+                    }
+                };
+                Toolkit.resultView = new NormalResultView($("#jobview"), "@{jobID}", shownHits, true, true, context);
+            });
+        }
   </script>

--- a/app/views/jobs/resultpanels/hhpred/hitlist.scala.html
+++ b/app/views/jobs/resultpanels/hhpred/hitlist.scala.html
@@ -173,21 +173,20 @@
         var shownHits = 100;
         var jobID = "@{jobID}";
 
-        $(function () {
-            var context = {
-                numHits: @result.num_hits,
-                toolName: "@tool.toolNameShort",
-                firstQueryStart: @result.HSPS.head.query.start,
-                firstQueryEnd: @result.HSPS.head.query.end,
-                query: {
-                    seq: "@result.query.seq",
-                    accession: "@result.query.accession"
-                }
-            };
-            Toolkit.resultView = new NormalResultView($("#jobview"), jobID, shownHits, true, true, context);
-        });
-
-        @if(result.num_hits > 0) {
+        @if(result.num_hits > 0){
+            $(function () {
+                var context = {
+                    numHits: @result.num_hits,
+                    toolName: "@tool.toolNameShort",
+                    firstQueryStart: @result.HSPS.head.query.start,
+                    firstQueryEnd: @result.HSPS.head.query.end,
+                    query: {
+                        seq: "@result.query.seq",
+                        accession: "@result.query.accession"
+                    }
+                };
+                Toolkit.resultView = new NormalResultView($("#jobview"), jobID, shownHits, true, true, context);
+            });
             new StructureModal($("#jobview"), $("#structureModal"));
         }
 

--- a/app/views/jobs/resultpanels/psiblast/hitlist.scala.html
+++ b/app/views/jobs/resultpanels/psiblast/hitlist.scala.html
@@ -111,23 +111,24 @@
 
 }
 <script>
-// config
-var shownHits = 500;
-
-$(function(){
-    var context = {
-        numHits: @result.num_hits,
-        toolName: "@tool.toolNameShort",
-        firstQueryStart: @result.HSPS.head.query_start,
-        firstQueryEnd: @result.HSPS.head.query_end,
-        belowEvalThreshold: @result.belowEvalThreshold,
-        query: {
-            seq: "@result.query.seq",
-            accession: "@result.query.accession"
-        }
-    };
-    Toolkit.resultView = new NormalResultView($("#jobview"), "@{jobID}", shownHits, true, false, context);
-});
+    // config
+    var shownHits = 500;
+    @if(result.num_hits > 0){
+        $(function(){
+            var context = {
+                numHits: @result.num_hits,
+                toolName: "@tool.toolNameShort",
+                firstQueryStart: @result.HSPS.head.query_start,
+                firstQueryEnd: @result.HSPS.head.query_end,
+                belowEvalThreshold: @result.belowEvalThreshold,
+                query: {
+                    seq: "@result.query.seq",
+                    accession: "@result.query.accession"
+                }
+        };
+            Toolkit.resultView = new NormalResultView($("#jobview"), "@{jobID}", shownHits, true, false, context);
+            });
+    }
 
 // TODO: move download into own scalajs
 window["@{tool.toolNameShort}_download"] = function(){

--- a/tel/runscripts/hmmer.sh
+++ b/tel/runscripts/hmmer.sh
@@ -133,38 +133,39 @@ updateProcessLog
 echo "done" >> ../results/process.log
 updateProcessLog
 
-
 echo "#Preparing output." >> ../results/process.log
 updateProcessLog
 
-#Convert to fasta format
-reformat_hhsuite.pl sto a3m ../results/${JOBID}.msa_sto $(readlink -f ../results/${JOBID}.msa_a3m)
+if [ -s "../results/${JOBID}.msa_sto" ]; then
 
-prepareForHMMER.py ../results/${JOBID}.outfile ../results/${JOBID}.outfilefl
+    #Convert to fasta format
+    reformat_hhsuite.pl sto a3m ../results/${JOBID}.msa_sto $(readlink -f ../results/${JOBID}.msa_a3m)
 
-hmmer2json.py -i ../results/${JOBID}.outfilefl \
+    prepareForHMMER.py ../results/${JOBID}.outfile ../results/${JOBID}.outfilefl
+
+    hmmer2json.py -i ../results/${JOBID}.outfilefl \
                   -o ../results/${JOBID}.json \
                   -m %desc.content \
                   -e %evalue.content > ../results/${JOBID}.list
 
-extractFasta.py ../results/${JOBID}.msa_a3m ../results/${JOBID}.list
+    extractFasta.py ../results/${JOBID}.msa_a3m ../results/${JOBID}.list
 
-reformat_hhsuite.pl a3m fas ../results/${JOBID}.msa_a3m.subset $(readlink -f ../results/output.aln_fas) -uc -l 32000
+    reformat_hhsuite.pl a3m fas ../results/${JOBID}.msa_a3m.subset $(readlink -f ../results/output.aln_fas) -uc -l 32000
 
-manipulate_json.py -k 'db' -v '%hmmerdb.content' ../results/${JOBID}.json
-#create tab separated file to feed into blastviz
-hmmerJson2tab.py ../results/${JOBID}.json ../results/query.json ../results/${JOBID}.tab
-blastviz_json.pl ../results/${JOBID}.tab %jobid.content ../results/ ../results/ >> ../logs/blastviz.log
+    manipulate_json.py -k 'db' -v '%hmmerdb.content' ../results/${JOBID}.json
+    #create tab separated file to feed into blastviz
+    hmmerJson2tab.py ../results/${JOBID}.json ../results/query.json ../results/${JOBID}.tab
+    blastviz_json.pl ../results/${JOBID}.tab %jobid.content ../results/ ../results/ >> ../logs/blastviz.log
 
-# add transmembrane prediction info to json
-manipulate_json.py -k 'TMPRED' -v "${TMPRED}" ../results/${JOBID}.json
+    # add transmembrane prediction info to json
+    manipulate_json.py -k 'TMPRED' -v "${TMPRED}" ../results/${JOBID}.json
 
-# add coiled coil prediction info to json
-manipulate_json.py -k 'COILPRED' -v "${COILPRED}" ../results/${JOBID}.json
+    # add coiled coil prediction info to json
+    manipulate_json.py -k 'COILPRED' -v "${COILPRED}" ../results/${JOBID}.json
 
-# Generate MSA in JSON
-fasta2json.py ../results/output.aln_fas ../results/alignment.json
-
+    # Generate MSA in JSON
+    fasta2json.py ../results/output.aln_fas ../results/alignment.json
+fi
 cd ../results
 rm -f *.hmm *.outfile* *.list *.msa_* ${JOBID}.fas firstSeq.fas
 


### PR DESCRIPTION
This fix solves this issue for HHblits, HHpred, PSI-BLAST, and HHomp.

HMMER is a bit different; when no hits are found, no JSONs are generated and therefore result.num_hits is not available. 

'hmmer.parseResult' should fail and blastviz.html is also unavailable. @zy4 do you have a clean solution for this? 

Test for this on Olt:
1. Use default sequence
2. pick nr_arc70 as database
3. set E-value to 1e-10