### PR TITLE
update version of psiblast

### DIFF
--- a/conf/tools.conf
+++ b/conf/tools.conf
@@ -527,7 +527,7 @@ ancescon {
     code: "pbl"
     section: "Search"
     frontend: 0
-    version: "2.6.0+"
+    version: "2.7.1+"
     updated: ""
     memory: 64
     threads: 8


### PR DESCRIPTION
this must be kept up-to-date in order to have valid result hash values