### PR TITLE
change way of modeller key backend validation

### DIFF
--- a/modules/jobs/src/main/scala/de/proteinevolution/jobs/models/JobSubmitError.scala
+++ b/modules/jobs/src/main/scala/de/proteinevolution/jobs/models/JobSubmitError.scala
@@ -26,4 +26,8 @@ object JobSubmitError {
     override val msg = "job id is already taken"
   }
 
+  case object ModellerKeyInvalid extends JobSubmitError {
+    override val msg = "modeller key is missing or incorrect"
+  }
+
 }

--- a/modules/results/src/main/twirl/views/resultpanels/hhpred/hitlist.scala.html
+++ b/modules/results/src/main/twirl/views/resultpanels/hhpred/hitlist.scala.html
@@ -203,7 +203,6 @@
             })
         };
 
-
         function @{tool.toolNameShort}_manual() {
             // Get selected templates and append parentID
             var formData = new FormData(document.getElementById("hhpred_templates"));


### PR DESCRIPTION
since the key is not checked in the runscript anymore
the check in the submission logic was redundant.
Still, we want to disallow submissions even if the frontendlogic
had restricted it by disabling the submission button.