### PR TITLE
sbt build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,5 @@ install:
   - npm install jsdom@9.12.0
 script:
  - bin/validate-code
- - $SBT_BIN test:compile test stage
+ - $SBT_BIN test stage
  - $HOME/cloc/cloc $(git ls-files)

--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,11 @@
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
+import Settings._
 
 inThisBuild(
   Seq(
     organization := "de.proteinevolution",
     scalaVersion := "2.12.8"
   )
-)
-
-lazy val commonSettings = Seq(
-  scalaJSProjects := Seq(client),
-  pipelineStages in Assets := Seq(scalaJSPipeline),
-  TwirlKeys.templateImports := Nil
 )
 
 lazy val buildInfoSettings = Seq(
@@ -25,12 +20,11 @@ lazy val buildInfoSettings = Seq(
   buildInfoPackage := "build"
 )
 
-lazy val coreSettings = commonSettings ++ Settings.compileSettings ++ Release.settings
-
-lazy val disableDocs = Seq[Setting[_]](
-  sources in (Compile, doc) := Seq.empty,
-  publishArtifact in (Compile, packageDoc) := false
-)
+lazy val coreSettings = Seq(
+  scalaJSProjects := Seq(client),
+  pipelineStages in Assets := Seq(scalaJSPipeline),
+  TwirlKeys.templateImports := Nil
+) ++ Settings.compileSettings ++ Release.settings
 
 import sbtcrossproject.{ crossProject, CrossType }
 
@@ -38,8 +32,7 @@ lazy val common = (crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pur
   .settings(
     name := "de.proteinevolution.common",
     libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    disableDocs
+    Settings.compileSettings
   )
   .settings(addCompilerPlugin(("org.scalamacros" % "paradise" % "2.1.0").cross(CrossVersion.full)))
 
@@ -47,210 +40,109 @@ lazy val commonJS  = common.js.dependsOn(base, tel)
 lazy val commonJVM = common.jvm.dependsOn(base, tel)
 
 lazy val results = (project in file("modules/results"))
-  .enablePlugins(PlayScala, JavaAppPackaging, SbtTwirl)
+  .commonSettings("de.proteinevolution.results")
+  .enablePlugins(PlayScala, SbtTwirl)
   .dependsOn(commonJVM, auth, jobs, help, ui, base, tools, util)
-  .settings(
-    name := "de.proteinevolution.results",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .settings(addCompilerPlugin(("org.scalamacros" % "paradise" % "2.1.0").cross(CrossVersion.full)))
   .settings(addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.9"))
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val help = (project in file("modules/help"))
-  .enablePlugins(PlayScala, JavaAppPackaging, SbtTwirl)
+  .commonSettings("de.proteinevolution.help")
+  .enablePlugins(PlayScala, SbtTwirl)
   .dependsOn(commonJVM, base)
-  .settings(
-    name := "de.proteinevolution.help",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val jobs = (project in file("modules/jobs"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
+  .enablePlugins(PlayScala)
   .dependsOn(commonJVM, auth, base, clusterApi, tel, tools, util)
-  .settings(
-    name := "de.proteinevolution.jobs",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .settings(addCompilerPlugin(("org.scalamacros" % "paradise" % "2.1.0").cross(CrossVersion.full)))
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val auth = (project in file("modules/auth"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
+  .commonSettings("de.proteinevolution.auth")
+  .enablePlugins(PlayScala)
   .dependsOn(commonJVM, base, tel, util)
-  .settings(
-    name := "de.proteinevolution.auth",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val base = (project in file("modules/base"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
-  .settings(
-    name := "de.proteinevolution.base",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
+  .commonSettings("de.proteinevolution.base")
+  .enablePlugins(PlayScala)
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val cluster = (project in file("modules/cluster"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
+  .commonSettings("de.proteinevolution.cluster")
+  .enablePlugins(PlayScala)
   .dependsOn(commonJVM, base, jobs, clusterApi)
-  .settings(
-    name := "de.proteinevolution.cluster",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val clusterApi = (project in file("modules/cluster-api"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
+  .commonSettings("de.proteinevolution.cluster.api")
+  .enablePlugins(PlayScala)
   .dependsOn(commonJVM, base)
-  .settings(
-    name := "de.proteinevolution.cluster.api",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val backend = (project in file("modules/backend"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
+  .commonSettings("de.proteinevolution.backend")
+  .enablePlugins(PlayScala)
   .dependsOn(commonJVM, base, auth, jobs, tel, tools)
-  .settings(
-    name := "de.proteinevolution.backend",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val search = (project in file("modules/search"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
+  .commonSettings("de.proteinevolution.search")
+  .enablePlugins(PlayScala)
   .dependsOn(commonJVM, base, auth, jobs, tools)
-  .settings(
-    name := "de.proteinevolution.search",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val ui = (project in file("modules/ui"))
-  .enablePlugins(PlayScala, JavaAppPackaging, SbtTwirl, BuildInfoPlugin)
+  .commonSettings("de.proteinevolution.ui")
+  .enablePlugins(PlayScala, SbtTwirl, BuildInfoPlugin)
   .dependsOn(commonJVM, base, tools)
   .settings(
-    name := "de.proteinevolution.ui",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs,
     buildInfoSettings
   )
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val message = (project in file("modules/message"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
+  .commonSettings("de.proteinevolution.message")
+  .enablePlugins(PlayScala)
   .dependsOn(commonJVM, base, auth, cluster, jobs, tools)
-  .settings(
-    name := "de.proteinevolution.message",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val verification = (project in file("modules/verification"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
+  .commonSettings("de.proteinevolution.verification")
+  .enablePlugins(PlayScala)
   .dependsOn(commonJVM, base, auth, ui, message, tel, tools)
-  .settings(
-    name := "de.proteinevolution.verification",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val migrations = (project in file("modules/migrations"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
-  .settings(
-    name := "de.proteinevolution.migrations",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
+  .commonSettings("de.proteinevolution.migrations")
+  .enablePlugins(PlayScala)
   .settings(scalacOptions --= Seq("-Ywarn-unused:imports"))
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val tel = (project in file("modules/tel"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
-  .settings(
-    name := "de.proteinevolution.tel",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
+  .commonSettings("de.proteinevolution.tel")
+  .enablePlugins(PlayScala)
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val tools = (project in file("modules/tools"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
+  .commonSettings("de.proteinevolution.tools")
+  .enablePlugins(PlayScala)
   .dependsOn(commonJVM, params)
   .settings(addCompilerPlugin(("org.scalamacros" % "paradise" % "2.1.0").cross(CrossVersion.full)))
-  .settings(
-    name := "de.proteinevolution.tools",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val util = (project in file("modules/util"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
+  .commonSettings("de.proteinevolution.util")
+  .enablePlugins(PlayScala)
   .dependsOn(commonJVM)
-  .settings(
-    name := "de.proteinevolution.util",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .disablePlugins(PlayLayoutPlugin)
 
 lazy val params = (project in file("modules/params"))
-  .enablePlugins(PlayScala, JavaAppPackaging)
+  .commonSettings("de.proteinevolution.params")
+  .enablePlugins(PlayScala)
   .dependsOn(commonJVM)
-  .settings(
-    name := "de.proteinevolution.params",
-    libraryDependencies ++= Dependencies.commonDeps,
-    Settings.compileSettings,
-    TwirlKeys.templateImports := Seq.empty,
-    disableDocs
-  )
   .settings(addCompilerPlugin(("org.scalamacros" % "paradise" % "2.1.0").cross(CrossVersion.full)))
   .disablePlugins(PlayLayoutPlugin)
 
@@ -260,41 +152,12 @@ lazy val root = (project in file("."))
     client,
     commonJVM,
     results,
-    jobs,
-    auth,
-    base,
     cluster,
-    help,
     backend,
     search,
-    ui,
     message,
     verification,
-    migrations,
-    tel,
-    tools,
-    util
-  )
-  .aggregate(
-    client,
-    commonJVM,
-    results,
-    jobs,
-    auth,
-    base,
-    cluster,
-    help,
-    backend,
-    search,
-    ui,
-    message,
-    verification,
-    clusterApi,
-    migrations,
-    tel,
-    tools,
-    util,
-    params
+    migrations
   )
   .settings(
     coreSettings,
@@ -305,9 +168,6 @@ lazy val root = (project in file("."))
     // TODO: TypescriptKeys.configFile := "/app/app/assets/tsconfig.json"
     // https://github.com/ArpNetworking/sbt-typescript#tsconfigjson-support-version--030
   )
-
-resolvers += "scalaz-bintray".at("http://dl.bintray.com/scalaz/releases")
-resolvers ++= Resolver.sonatypeRepo("releases") :: Resolver.sonatypeRepo("snapshots") :: Nil
 
 lazy val client = (project in file("modules/client"))
   .enablePlugins(ScalaJSPlugin, ScalaJSWeb)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,8 +30,6 @@ object Dependencies {
     "org.typelevel"        %% "cats-core"                % catsV,
     "org.typelevel"        %% "cats-effect"              % "1.1.0",
     "com.chuusai"          %% "shapeless"                % "2.3.3",
-    "org.atnos"            %% "eff"                      % "5.3.0",
-    "org.tpolecat"         %% "atto-core"                % "0.6.4",
     "com.vmunier"          %% "scalajs-scripts"          % "1.1.1",
     "com.mohiva"           %% "play-html-compressor"     % "0.7.1",
     "com.dripower"         %% "play-circe"               % "2711.0",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,4 +1,6 @@
-import sbt.Keys.scalacOptions
+import play.twirl.sbt.Import.TwirlKeys
+import sbt.Keys._
+import sbt.{Compile, Project, Setting}
 
 object Settings {
 
@@ -58,5 +60,21 @@ object Settings {
   lazy val compileSettings = Seq(scalacOptions ++= allFlags)
 
   lazy val sjsCompileSettings = Seq(scalacOptions ++= coreFlags)
+
+  lazy val disableDocs = Seq[Setting[_]](
+    sources in (Compile, doc) := Seq.empty,
+    publishArtifact in (Compile, packageDoc) := false
+  )
+
+  implicit class SettingsFromProject(project: Project) {
+    def commonSettings(projectName: String): Project =
+      project.settings(
+        name := projectName,
+        libraryDependencies ++= Dependencies.commonDeps,
+        Settings.compileSettings,
+        TwirlKeys.templateImports := Seq.empty,
+        disableDocs
+      )
+  }
 
 }


### PR DESCRIPTION
* extracted some bits to project/Settings.scala
* removed unused dependencies

The thing that may requires some discussion is removal of aggregate. I think it may speedup a bit most of sbt tasks, once project start to have tests in submodules then we should e.g. create an alias for `test` so it will run it in submodules that have tests.