### PR TITLE
issue #830: decouple cluster load from qstat

### DIFF
--- a/modules/cluster-api/src/main/scala/de/proteinevolution/cluster/api/JobLoad.scala
+++ b/modules/cluster-api/src/main/scala/de/proteinevolution/cluster/api/JobLoad.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Dept. Protein Evolution, Max Planck Institute for Developmental Biology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.proteinevolution.cluster.api
+
+object JobLoad {
+
+  @volatile private var runningJobs: Long = 0
+
+  def watch(): Unit = runningJobs += 1
+
+  def unwatch(): Unit = runningJobs -= 1
+
+  def get: Long = runningJobs
+
+}

--- a/modules/cluster-api/src/main/scala/de/proteinevolution/cluster/api/JobLoad.scala
+++ b/modules/cluster-api/src/main/scala/de/proteinevolution/cluster/api/JobLoad.scala
@@ -20,9 +20,9 @@ object JobLoad {
 
   @volatile private var runningJobs: Long = 0
 
-  def watch(): Unit = runningJobs += 1
+  @inline def watch(): Unit = runningJobs += 1
 
-  def unwatch(): Unit = runningJobs -= 1
+  @inline def unwatch(): Unit = runningJobs -= 1
 
   def get: Long = runningJobs
 

--- a/modules/cluster-api/src/main/scala/de/proteinevolution/cluster/api/SGELoad.scala
+++ b/modules/cluster-api/src/main/scala/de/proteinevolution/cluster/api/SGELoad.scala
@@ -16,13 +16,14 @@
 
 package de.proteinevolution.cluster.api
 
-object JobLoad {
+object SGELoad {
 
   @volatile private var runningJobs: Long = 0
 
-  @inline def watch(): Unit = runningJobs += 1
+  @inline def push(): Unit = runningJobs += 1
 
-  @inline def unwatch(): Unit = runningJobs -= 1
+  // prevent negative values if the first job fails
+  @inline def pop(): Unit = if (runningJobs > 0) runningJobs -= 1
 
   def get: Long = runningJobs
 

--- a/modules/cluster/src/main/scala/de/proteinevolution/cluster/ClusterSource.scala
+++ b/modules/cluster/src/main/scala/de/proteinevolution/cluster/ClusterSource.scala
@@ -22,7 +22,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import de.proteinevolution.cluster.ClusterSource.UpdateLoad
 import de.proteinevolution.cluster.api.Polling.PolledJobs
-import de.proteinevolution.cluster.api.{ JobLoad, QStat }
+import de.proteinevolution.cluster.api.{ SGELoad, QStat }
 import de.proteinevolution.common.models.ConstantsV2
 import javax.inject.{ Inject, Singleton }
 
@@ -44,7 +44,7 @@ final class ClusterSource @Inject()(constants: ConstantsV2)(
 
   private[this] def updateLoad(): Unit = {
     // 32 Tasks are 100% - calculate the load from this.
-    val load: Double = JobLoad.get.toDouble / constants.loadPercentageMarker
+    val load: Double = SGELoad.get.toDouble / constants.loadPercentageMarker
     system.eventStream.publish(UpdateLoad(load))
   }
 

--- a/modules/cluster/src/main/scala/de/proteinevolution/cluster/ClusterSource.scala
+++ b/modules/cluster/src/main/scala/de/proteinevolution/cluster/ClusterSource.scala
@@ -22,7 +22,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import de.proteinevolution.cluster.ClusterSource.UpdateLoad
 import de.proteinevolution.cluster.api.Polling.PolledJobs
-import de.proteinevolution.cluster.api.QStat
+import de.proteinevolution.cluster.api.{ JobLoad, QStat }
 import de.proteinevolution.common.models.ConstantsV2
 import javax.inject.{ Inject, Singleton }
 
@@ -37,17 +37,24 @@ final class ClusterSource @Inject()(constants: ConstantsV2)(
     ec: ExecutionContext
 ) {
 
-  private[this] def update(): Unit = {
+  private[this] def qStat(): Unit = {
     val qStat = QStat("qstat -xml".!!)
-    // 32 Tasks are 100% - calculate the load from this.
-    val load: Double = qStat.totalJobs().toDouble / constants.loadPercentageMarker
     system.eventStream.publish(PolledJobs(qStat))
+  }
+
+  private[this] def updateLoad(): Unit = {
+    // 32 Tasks are 100% - calculate the load from this.
+    val load: Double = JobLoad.get.toDouble / constants.loadPercentageMarker
     system.eventStream.publish(UpdateLoad(load))
   }
 
-  private[this] val tick: Source[NotUsed, Cancellable] = Source.tick(0.seconds, constants.pollingInterval, NotUsed)
+  private[this] val qStatTick: Source[NotUsed, Cancellable] = Source.tick(5.seconds, constants.pollingInterval, NotUsed)
 
-  tick.runForeach(_ => update())
+  private[this] val loadTick: Source[NotUsed, Cancellable] = Source.tick(0.seconds, 1.second, NotUsed)
+
+  qStatTick.runForeach(_ => qStat())
+
+  loadTick.runForeach(_ => updateLoad())
 
 }
 

--- a/modules/common/src/main/scala/de/proteinevolution/common/models/ConstantsV2.scala
+++ b/modules/common/src/main/scala/de/proteinevolution/common/models/ConstantsV2.scala
@@ -88,9 +88,9 @@ class ConstantsV2 @Inject()(config: Configuration) {
   /** Deletes registered accounts after this time frame */
   final val userDeletingRegistered: Int = 24 //months
 
-  // Polling and cluster load checking settings
+  // qstat long polling in order to detect zombie jobs, not used for cluster load calc anymore
   /** Interval of the qstat requests */
-  final val pollingInterval: FiniteDuration = 1 second
+  final val pollingInterval: FiniteDuration = 5 minutes
 
   /** The marker for 100% load capacity */
   final val loadPercentageMarker: Int = 32 // Jobs

--- a/modules/jobs/src/main/scala/de/proteinevolution/jobs/actors/JobActor.scala
+++ b/modules/jobs/src/main/scala/de/proteinevolution/jobs/actors/JobActor.scala
@@ -169,6 +169,7 @@ class JobActor @Inject()(
         currentExecutionContexts = currentExecutionContexts.filter(_._1 != jobID)
       }
     }
+    SGELoad.pop()
   }
 
   private def delete(job: Job, verbose: Boolean): Unit = {
@@ -603,7 +604,6 @@ class JobActor @Inject()(
               // Tell the user that their job finished via eMail (can be either failed or done)
               sendJobUpdateMail(job)
             }
-            SGELoad.pop()
           } else {
             updateJobState(job)
           }

--- a/modules/jobs/src/main/scala/de/proteinevolution/jobs/actors/JobActor.scala
+++ b/modules/jobs/src/main/scala/de/proteinevolution/jobs/actors/JobActor.scala
@@ -218,7 +218,7 @@ class JobActor @Inject()(
     currentJobs = currentJobs.updated(job.jobID, job)
 
     // update the cluster load
-    if (job.status == JobState.Running)
+    if (job.status == JobState.Queued)
       SGELoad.push()
 
     // Update job in the database and notify watcher upon completion

--- a/modules/jobs/src/main/scala/de/proteinevolution/jobs/actors/JobActor.scala
+++ b/modules/jobs/src/main/scala/de/proteinevolution/jobs/actors/JobActor.scala
@@ -28,7 +28,7 @@ import de.proteinevolution.auth.dao.UserDao
 import de.proteinevolution.auth.models.MailTemplate.JobFinishedMail
 import de.proteinevolution.base.helpers.ToolkitTypes
 import de.proteinevolution.cluster.api.Polling.PolledJobs
-import de.proteinevolution.cluster.api.{ JobLoad, QStat, Qdel }
+import de.proteinevolution.cluster.api.{ SGELoad, QStat, Qdel }
 import de.proteinevolution.common.models.ConstantsV2
 import de.proteinevolution.common.models.database.jobs.JobState._
 import de.proteinevolution.common.models.database.jobs._
@@ -168,7 +168,6 @@ class JobActor @Inject()(
       if (currentExecutionContexts.contains(jobID)) {
         currentExecutionContexts = currentExecutionContexts.filter(_._1 != jobID)
       }
-      JobLoad.unwatch()
     }
   }
 
@@ -220,7 +219,7 @@ class JobActor @Inject()(
 
     // update the cluster load
     if (job.status == JobState.Running)
-      JobLoad.watch()
+      SGELoad.push()
 
     // Update job in the database and notify watcher upon completion
     jobDao
@@ -604,6 +603,7 @@ class JobActor @Inject()(
               // Tell the user that their job finished via eMail (can be either failed or done)
               sendJobUpdateMail(job)
             }
+            SGELoad.pop()
           } else {
             updateJobState(job)
           }

--- a/modules/jobs/src/main/scala/de/proteinevolution/jobs/actors/JobActor.scala
+++ b/modules/jobs/src/main/scala/de/proteinevolution/jobs/actors/JobActor.scala
@@ -28,7 +28,7 @@ import de.proteinevolution.auth.dao.UserDao
 import de.proteinevolution.auth.models.MailTemplate.JobFinishedMail
 import de.proteinevolution.base.helpers.ToolkitTypes
 import de.proteinevolution.cluster.api.Polling.PolledJobs
-import de.proteinevolution.cluster.api.{ QStat, Qdel }
+import de.proteinevolution.cluster.api.{ JobLoad, QStat, Qdel }
 import de.proteinevolution.common.models.ConstantsV2
 import de.proteinevolution.common.models.database.jobs.JobState._
 import de.proteinevolution.common.models.database.jobs._
@@ -155,33 +155,21 @@ class JobActor @Inject()(
     }
   }
 
-  private def removeJob(jobID: String): Boolean = {
-    var wasActive = currentJobs.contains(jobID)
-    // If the job is in the current jobs remove it
-    if (wasActive) {
-      currentJobs = currentJobs.filter(_._1 != jobID)
-    }
-
+  private def removeJob(jobID: String): Unit = {
     // Save Job Event Log to the collection and remove it from the map afterwards
     if (currentJobLogs.contains(jobID)) {
+      currentJobs = currentJobs.filter(_._1 != jobID)
       jobDao.addJobLog(currentJobLogs(jobID))
       currentJobLogs = currentJobLogs.filter(_._1 != jobID)
-      wasActive = true
+      if (runningExecutions.contains(jobID)) {
+        runningExecutions(jobID).terminate()
+        runningExecutions = runningExecutions.filter(_._1 != jobID)
+      }
+      if (currentExecutionContexts.contains(jobID)) {
+        currentExecutionContexts = currentExecutionContexts.filter(_._1 != jobID)
+      }
+      JobLoad.unwatch()
     }
-
-    // If the job appears in the running Execution, terminate it
-    if (runningExecutions.contains(jobID)) {
-      runningExecutions(jobID).terminate()
-      runningExecutions = runningExecutions.filter(_._1 != jobID)
-      wasActive = true
-    }
-
-    // if the job appears in the current execution contexts, remove it from there too
-    if (currentExecutionContexts.contains(jobID)) {
-      currentExecutionContexts = currentExecutionContexts.filter(_._1 != jobID)
-      wasActive = true
-    }
-    wasActive
   }
 
   private def delete(job: Job, verbose: Boolean): Unit = {
@@ -229,6 +217,10 @@ class JobActor @Inject()(
   private def updateJobState(job: Job): Future[Job] = {
     // Push the updated job into the current jobs
     currentJobs = currentJobs.updated(job.jobID, job)
+
+    // update the cluster load
+    if (job.status == JobState.Running)
+      JobLoad.watch()
 
     // Update job in the database and notify watcher upon completion
     jobDao
@@ -620,25 +612,18 @@ class JobActor @Inject()(
 
     // Checks the current jobs against the currently running cluster jobs to see if there are any dead jobs
     case PolledJobs(qStat: QStat) =>
-      val clusterJobIDs = qStat.qStatJobs.map(_.sgeID)
-      log.info(
-        s"[JobActor[$jobActorNumber].PolledJobs] sge Jobs to check: ${clusterJobIDs
-          .mkString(", ")}\nactor Jobs to check:${currentJobs.values.flatMap(_.clusterData.map(_.sgeID)).mkString(", ")}"
-      )
-      currentJobs.values.foreach { job =>
-        job.clusterData match {
-          case Some(clusterData) =>
-            val jobInCluster = clusterJobIDs.contains(clusterData.sgeID)
-            log.info(
-              s"[JobActor[$jobActorNumber].PolledJobs] Job ${job.jobID} with sgeID ${clusterData.sgeID}: ${if (jobInCluster) "active"
-              else "inactive"}"
-            )
-            if ((!job.isFinished && !jobInCluster) || isOverDue(job) || sgeFailed(clusterData.sgeID, qStat)) {
-              self ! JobStateChanged(job.jobID, Error)
-            }
-          case None => NotUsed
-          // also delete
-        }
+      for {
+        job         <- currentJobs.values
+        clusterData <- job.clusterData
+      } {
+        val clusterJobIDs = qStat.qStatJobs.map(_.sgeID)
+        val jobInCluster  = clusterJobIDs.contains(clusterData.sgeID)
+        log.info(
+          s"[JobActor[$jobActorNumber].PolledJobs] Job ${job.jobID} with sgeID ${clusterData.sgeID}: ${if (jobInCluster) "active"
+          else "inactive"}"
+        )
+        if ((!job.isFinished && !jobInCluster) || isOverDue(job) || sgeFailed(clusterData.sgeID, qStat))
+          self ! JobStateChanged(job.jobID, Error)
       }
 
     // Sets the cluster job ID for a job

--- a/modules/jobs/src/main/scala/de/proteinevolution/jobs/controllers/ClusterApiController.scala
+++ b/modules/jobs/src/main/scala/de/proteinevolution/jobs/controllers/ClusterApiController.scala
@@ -16,20 +16,20 @@
 
 package de.proteinevolution.jobs.controllers
 
+import better.files._
 import de.proteinevolution.base.controllers.ToolkitController
-import de.proteinevolution.jobs.actors.JobActor.{ JobStateChanged, SetSGEID }
-import de.proteinevolution.jobs.services.JobActorAccess
 import de.proteinevolution.common.models.ConstantsV2
 import de.proteinevolution.common.models.database.jobs.JobState.{ Done, Error, Queued, Running }
+import de.proteinevolution.jobs.actors.JobActor.{ JobStateChanged, SetSGEID }
+import de.proteinevolution.jobs.services.JobActorAccess
 import javax.inject.{ Inject, Singleton }
 import play.api.mvc.{ Action, AnyContent, ControllerComponents }
-import better.files._
 
 @Singleton
 class ClusterApiController @Inject()(constants: ConstantsV2, jobActorAccess: JobActorAccess, cc: ControllerComponents)
     extends ToolkitController(cc) {
 
-  def setJobStatus(status: String, jobID: String, key: String) = Action {
+  def setJobStatus(status: String, jobID: String, key: String): Action[AnyContent] = Action {
     if (checkKey(jobID, key)) {
       val jobStatus = status match {
         case "done"    => Done


### PR DESCRIPTION
since we have the exact count of running jobs, we don't
need to poll via qstat every second.
Instead keep calling qstat ONLY for detecting zombie jobs
but with an increased polling interval (5 mins instead of 1 sec)