### PR TITLE
closes #878

### DIFF
--- a/conf/tools.conf
+++ b/conf/tools.conf
@@ -202,7 +202,7 @@ Tools {
     code: "hhbl"
     section: "Search"
     frontend: 0
-    version: ""
+    version: "3.2.0"
     updated: ""
     memory: 74
     threads: 8
@@ -266,7 +266,7 @@ Tools {
     input_placeholder = "Enter a protein sequence/multiple sequence alignment in FASTA/CLUSTAL/A3M format."
     section: "Search"
     frontend: 0
-    version: "3.0.0beta"
+    version: "v3.2.0"
     updated: ""
     memory: 96
     threads: 8


### PR DESCRIPTION
Updated HHsuite to v3.2.0. It comprises binaries and scripts for HHpred and HHblits.