### PR TITLE
Do not store params in localStorage

### DIFF
--- a/conf/tools.conf
+++ b/conf/tools.conf
@@ -6,7 +6,7 @@
 #Specify hardruntime in seconds
 
 # A new version indicates that the frontend should reload the configuration
-version: "0.0.2"
+version: "0.0.4"
 
 Tools {
 

--- a/frontend/src/components/tools/parameters/SelectParameter.vue
+++ b/frontend/src/components/tools/parameters/SelectParameter.vue
@@ -2,7 +2,6 @@
     <b-form-group :label="$t('tools.parameters.labels.' + parameter.name)">
 
         <multiselect v-model="selected"
-                     :color='red'
                      :multiple="isMulti"
                      :max="isMulti ? parameter.maxSelectedOptions : null"
                      :allowEmpty="isMulti"

--- a/frontend/src/store/plugins/localStoragePlugin.ts
+++ b/frontend/src/store/plugins/localStoragePlugin.ts
@@ -17,7 +17,15 @@ const localStoragePlugin = (store: Store<RootState>) => {
     // save tools and version in localStorage whenever they are updated
     store.subscribe((mutation, state) => {
         if (mutation.type.startsWith('tools')) {
-            localStorage.setItem('tools', JSON.stringify((state as any).tools.tools));
+
+            const tools = JSON.parse(JSON.stringify((state as any).tools.tools));
+
+            // do not save parameters in localStorage as they updated frequently (e.g. databases of HHpred, PSI-BLAST)
+            tools.forEach((element: { parameters: any; }) => {
+                delete element.parameters;
+            });
+
+            localStorage.setItem('tools', JSON.stringify(tools));
             localStorage.setItem('toolsVersion', (state as any).tools.version);
         } else if (mutation.type.startsWith('jobs')) {
             localStorage.setItem('jobs', JSON.stringify((state as any).jobs.jobs));


### PR DESCRIPTION
They get updated frequently. For instance, the databases of tools
such as HHpred and PSI-BLAST are updated on a regular basis.